### PR TITLE
Set random user id outside platform

### DIFF
--- a/features/post_submission.feature
+++ b/features/post_submission.feature
@@ -72,7 +72,7 @@ Feature: Post submission
       "tags": "",
       "jobname": "101",
       "jobdata": "{\"taskPath\":\"$ROOT_PATH/FranceIOI/Contests/2018/Algorea_finale/plateau\",\"extraParams\":{\"solutionFilename\":\"101.py\",\"solutionContent\":\"print('ici')\",\"solutionLanguage\":\"python3\",\"solutionDependencies\":\"@defaultDependencies-python3\",\"solutionFilterTests\":\"@defaultFilterTests-python3\",\"solutionId\":\"sol0-101.py\",\"solutionExecId\":\"exec0-101.py\",\"defaultSolutionCompParams\":{\"memoryLimitKb\":131072,\"timeLimitMs\":10000,\"stdoutTruncateKb\":-1,\"stderrTruncateKb\":-1,\"useCache\":true,\"getFiles\":[]},\"defaultSolutionExecParams\":{\"memoryLimitKb\":64000,\"timeLimitMs\":200,\"stdoutTruncateKb\":-1,\"stderrTruncateKb\":-1,\"useCache\":true,\"getFiles\":[]}},\"options\":{\"locale\":\"fr\"}}",
-      "jobusertaskid": "1000-1-1",
+      "jobusertaskid": "1000-102-1",
       "debugPassword": "test"
     }
     """
@@ -137,7 +137,7 @@ Feature: Post submission
       "tags": "",
       "jobname": "101",
       "jobdata": "{\"taskPath\":\"$ROOT_PATH/FranceIOI/Contests/2018/Algorea_finale/plateau\",\"extraParams\":{\"solutionFilename\":\"101.py\",\"solutionContent\":\"print('ici')\",\"solutionLanguage\":\"python3\",\"solutionDependencies\":\"@defaultDependencies-python3\",\"solutionFilterTests\":[\"id-*.in\"],\"solutionId\":\"sol0-101.py\",\"solutionExecId\":\"exec0-101.py\",\"defaultSolutionCompParams\":{\"memoryLimitKb\":131072,\"timeLimitMs\":10000,\"stdoutTruncateKb\":-1,\"stderrTruncateKb\":-1,\"useCache\":true,\"getFiles\":[]},\"defaultSolutionExecParams\":{\"memoryLimitKb\":64000,\"timeLimitMs\":200,\"stdoutTruncateKb\":-1,\"stderrTruncateKb\":-1,\"useCache\":true,\"getFiles\":[]}},\"extraTests\":[{\"name\":\"id-102.in\",\"content\":\"test\"},{\"name\":\"id-102.out\",\"content\":\"ici\"}],\"executions\":[{\"id\":\"testExecution\",\"idSolution\":\"@solutionId\",\"filterTests\":[\"id-*.in\"],\"runExecution\":\"@defaultSolutionExecParams\"}],\"options\":{\"locale\":\"fr\"}}",
-      "jobusertaskid": "1000-1-1",
+      "jobusertaskid": "1000-103-1",
       "debugPassword": "test"
     }
     """

--- a/features/support/hooks.ts
+++ b/features/support/hooks.ts
@@ -7,8 +7,7 @@ import {init} from '../../src/server';
 
 import chai from 'chai';
 import chaiSubset from 'chai-subset';
-import {setRandomIdGenerator as generator1} from '../../src/submissions';
-import {setRandomIdGenerator as generator2} from '../../src/grader_webhook';
+import {setRandomIdGenerator} from '../../src/util';
 chai.use(chaiSubset);
 
 let testServer: Server;
@@ -41,7 +40,7 @@ BeforeAll(function () {
   dotenv.config({path: path.resolve(__dirname, '../../.env')});
 
   Db.init();
-  mockIdGenerators();
+  setRandomIdGenerator(randomIdGenerator);
   testServer = init();
 });
 
@@ -62,11 +61,6 @@ async function cleanDatabase(): Promise<void> {
   for (const table of tablesToClear) {
     await Db.execute(`DELETE FROM ${table} WHERE 1`, {});
   }
-}
-
-function mockIdGenerators(): void {
-  generator1(randomIdGenerator);
-  generator2(randomIdGenerator);
 }
 
 export {

--- a/src/grader_webhook.ts
+++ b/src/grader_webhook.ts
@@ -53,12 +53,6 @@ export interface TokenParams {
   },
 }
 
-let randomIdGenerator = getRandomId;
-
-export function setRandomIdGenerator(getRandomId: () => string): void {
-  randomIdGenerator = getRandomId;
-}
-
 async function createNewTest(idSubmission: string, idTask: string, testName: string, idSubtask: string|null): Promise<TaskTest> {
   let maxRank = await Db.querySingleScalarResult<number>(`SELECT MAX(tm_tasks_tests.iRank) from tm_tasks_tests
   JOIN tm_submissions ON tm_submissions.idTask = tm_tasks_tests.idTask
@@ -70,7 +64,7 @@ async function createNewTest(idSubmission: string, idTask: string, testName: str
     maxRank = 0;
   }
 
-  const ID = randomIdGenerator();
+  const ID = getRandomId();
 
   await Db.execute('INSERT INTO tm_tasks_tests (ID, idTask, idSubtask, sGroupType, iRank, bActive, sName) values (:ID, :idTask, :idSubtask, \'Evaluation\', :iRank, 1, :sName)', {
     ID,
@@ -193,7 +187,7 @@ ${thisCompilMsg}`;
       }
 
       await Db.execute('insert ignore into tm_submissions_tests (ID, idSubmission, iErrorCode, idTest, iScore, sLog) values (:ID, :idSubmission, :iErrorCode, :idTest, :iScore, :sLog);', {
-        ID: randomIdGenerator(),
+        ID: getRandomId(),
         idSubmission: tokenParams.sTaskName,
         idTest: test.ID,
         iScore,
@@ -255,7 +249,7 @@ ${thisCompilMsg}`;
             }
             const idSubtask = curSubtask.ID;
 
-            const submSubtaskId = randomIdGenerator();
+            const submSubtaskId = getRandomId();
             subTaskIdBySubmissionSubTaskId[submSubtaskId] = idSubtask;
 
             await Db.execute('INSERT INTO tm_submissions_subtasks (ID, bSuccess, iScore, idSubtask, idSubmission) VALUES(:submissionSubtaskId, 0, 0, :idSubtask, :idSubmission);', {
@@ -333,7 +327,7 @@ ${thisCompilMsg}`;
             bNoFeedback = testReport.execution?.noFeedback ? 1 : 0;
 
             await Db.execute('insert ignore into tm_submissions_tests (ID, idSubmission, idTest, iScore, iTimeMs, iMemoryKb, iErrorCode, sErrorMsg, sExpectedOutput, idSubmissionSubtask, bNoFeedback) values (:ID, :idSubmission, :idTest, :iScore, :iTimeMs, :iMemoryKb, :iErrorCode, :sErrorMsg, :sExpectedOutput, :idSubmissionSubtask, :bNoFeedback);', {
-              ID: randomIdGenerator(),
+              ID: getRandomId(),
               idSubmission: tokenParams.sTaskName,
               idTest: test.ID,
               iScore: 0,
@@ -370,7 +364,7 @@ ${thisCompilMsg}`;
           const sOutput = testReport.execution?.stdout.data.trimEnd();
 
           await Db.execute('insert ignore into tm_submissions_tests (ID, idSubmission, idTest, iScore, iTimeMs, iMemoryKb, iErrorCode, sOutput, sExpectedOutput, sErrorMsg, sLog, jFiles, idSubmissionSubtask, bNoFeedback) values (:ID, :idSubmission, :idTest, :iScore, :iTimeMs, :iMemoryKb, :iErrorCode, :sOutput, :sExpectedOutput, :sErrorMsg, :sLog, :jFiles, :idSubmissionSubtask, :bNoFeedback);', {
-            ID: randomIdGenerator(),
+            ID: getRandomId(),
             idSubmission: tokenParams.sTaskName,
             idTest: test.ID,
             iScore,

--- a/src/submissions.ts
+++ b/src/submissions.ts
@@ -90,12 +90,6 @@ export interface SubmissionOutput extends SubmissionNormalized {
   tests?: SubmissionTestNormalized[],
 }
 
-let randomIdGenerator = getRandomId;
-
-export function setRandomIdGenerator(getRandomId: () => string): void {
-  randomIdGenerator = getRandomId;
-}
-
 export async function getPlatformTokenParams(taskId: string, token?: string|null, platform?: string|null): Promise<PlatformTokenParameters> {
   if (!platform && process.env.TEST_MODE && process.env.TEST_MODE_PLATFORM_NAME) {
     platform = process.env.TEST_MODE_PLATFORM_NAME;
@@ -165,8 +159,8 @@ export async function createSubmission(submissionDataPayload: unknown): Promise<
   const mode = submissionData.userTests && submissionData.userTests.length ? SubmissionMode.UserTest : SubmissionMode.Submitted;
 
   // save source code (with bSubmission = 1)
-  const idNewSourceCode = randomIdGenerator();
-  const idSubmission = randomIdGenerator();
+  const idNewSourceCode = getRandomId();
+  const idSubmission = getRandomId();
   const sourceCodeParams = JSON.stringify({
     sLangProg: submissionData.answer.language,
   });
@@ -193,7 +187,7 @@ export async function createSubmission(submissionDataPayload: unknown): Promise<
 
     if ('UserTest' === mode && submissionData.userTests && submissionData.userTests.length) {
       const valuesToInsert = submissionData.userTests.map((test, index) => ([
-        randomIdGenerator(),
+        getRandomId(),
         params.idUser,
         params.idPlatform,
         params.idTaskLocal,

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,11 +7,21 @@ function randomIntFromInterval(min: number, max: number): number {
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
 
-export function getRandomId(): string {
+function defaultRandomIdGenerator(): string {
   let rand = String(randomIntFromInterval(100000, 999999999));
   rand += String(randomIntFromInterval(1000000, 999999999));
 
   return rand;
+}
+
+let randomIdGenerator = defaultRandomIdGenerator;
+
+export function getRandomId(): string {
+  return randomIdGenerator();
+}
+
+export function setRandomIdGenerator(getRandomId: () => string): void {
+  randomIdGenerator = getRandomId;
 }
 
 export function decode<T>(decoder: D.Decoder<unknown, T>) {


### PR DESCRIPTION
When this is a test user, avoid blocking the grader queue because several people use the grader queue at the same time. If several users use the grader queue at the same time on the same task outside a platform, they will all have the same jobUserTaskId, and this is problematic since the grader queue will re-start the submission everytime and cancel the previous ones made with this identifier. To prevent this, we generate a random identifier.