### PR TITLE
Add an option to return submission results with test content

### DIFF
--- a/features/get_submission.feature
+++ b/features/get_submission.feature
@@ -179,6 +179,169 @@ Feature: Get submission
       }
       """
 
+  Scenario: Get evaluated submission by id with tests
+    Given the database has the following table "tm_submissions":
+      | ID   | idUser | idPlatform | idTask | sDate      | idSourceCode | bManualCorrection | bSuccess | nbTestsTotal | nbTestsPassed | iScore | bCompilError | bEvaluated | sMetadata        | bConfirmed | sMode     | iChecksum | iVersion   |
+      | 6000 | 1      | 1          | 1000   | 2023-04-03 | 7001         | 0                 | 0        | 0            | 0             | 0      | 0            | 1          | {"errorline": 5} | 0          | Submitted | 0         | 2147483647 |
+    And the database has the following table "tm_submissions_subtasks":
+      | ID   | bSuccess | iScore | idSubtask | idSubmission | iVersion   |
+      | 7000 | 0        | 50     | 4000      | 6000         | 2147483647 |
+      | 7001 | 1        | 100    | 4001      | 6000         | 2147483647 |
+    And the database has the following table "tm_submissions_tests":
+      | ID   | idSubmission | idTest | iScore | iTimeMs | iMemoryKb | iErrorCode | sOutput | sErrorMsg | sMetadata        | sLog   | bNoFeedback | iVersion   | idSubmissionSubtask |
+      | 8000 | 6000         | 5000   | 100     | 5       | 22       | 0          |         |           | {"errorline": 4} |        | 1           | 2147483647 | 7000                |
+      | 8001 | 6000         | 5001   | 0       | 2       | 25       | 1          |         | Erreur    |                  |        | 1           | 2147483647 | 7000                |
+      | 8002 | 6000         | 5002   | 100     | 3       | 26       | 0          |         |           |                  |        | 1           | 2147483647 | 7001                |
+    And the database has the following table "tm_source_codes":
+      | ID   | idUser | idPlatform | idTask | sDate      | sParams                | sName              | sSource      | bEditable | bSubmission | sType | bActive | iRank | iVersion   |
+      | 7001 | 1      | 1          | 1000   | 2023-04-03 | {"sLangProg":"python"} | 485380303499640413 | print("ici") | 0         | 1           | User  | 0       | 0     | 2147483647 |
+    When I send a GET request to "/submissions/6000?withTests"
+    Then the response status code should be 200
+    And the response body should be the following JSON:
+      """
+      {
+        "id": "6000",
+        "success": false,
+        "totalTestsCount": 0,
+        "passedTestsCount": 0,
+        "score": 0,
+        "compilationError": false,
+        "compilationMessage": null,
+        "errorMessage": null,
+        "evaluated": true,
+        "confirmed": false,
+        "manualCorrection": false,
+        "manualScoreDiffComment": null,
+        "metadata": {
+          "errorline": 5
+        },
+        "mode": "Submitted",
+        "sourceCode": {
+           "id": "7001",
+           "name": "485380303499640413",
+           "source": "print(\"ici\")",
+           "type": "User",
+           "params": {
+             "sLangProg": "python"
+           },
+           "rank": 0,
+           "active": false,
+           "editable": false
+        },
+        "subTasks": [
+          {
+            "id": "7000",
+            "success": false,
+            "score": 50,
+            "subtaskId": "4000"
+          },
+          {
+            "id": "7001",
+            "success": true,
+            "score": 100,
+            "subtaskId": "4001"
+          }
+        ],
+        "tests": [
+          {
+            "id": "8000",
+            "testId": "5000",
+            "score": 100,
+            "timeMs": 5,
+            "memoryKb": 22,
+            "errorCode": 0,
+            "output": "",
+            "expectedOutput": null,
+            "errorMessage": "",
+            "metadata": {
+              "errorline": 4
+            },
+            "log": "",
+            "noFeedback": true,
+            "files": null,
+            "submissionSubtaskId": "7000",
+            "test": {
+              "id": "5000",
+              "submissionId": null,
+              "groupType": "Evaluation",
+              "userId": null,
+              "platformId": null,
+              "rank": 0,
+              "active": true,
+              "name": null,
+              "input": "16",
+              "output": "20",
+              "subtaskId": "4000",
+              "taskId": "1000",
+              "clientId": null
+            }
+          },
+          {
+            "id": "8001",
+            "testId": "5001",
+            "score": 0,
+            "timeMs": 2,
+            "memoryKb": 25,
+            "errorCode": 1,
+            "output": "",
+            "expectedOutput": null,
+            "errorMessage": "Erreur",
+            "metadata": null,
+            "log": "",
+            "noFeedback": true,
+            "files": null,
+            "submissionSubtaskId": "7000",
+            "test": {
+              "id": "5001",
+              "submissionId": null,
+              "groupType": "Evaluation",
+              "userId": null,
+              "platformId": null,
+              "rank": 1,
+              "active": true,
+              "name": null,
+              "input": "10",
+              "output": "15",
+              "subtaskId": "4000",
+              "taskId": "1000",
+              "clientId": null
+            }
+          },
+          {
+            "id": "8002",
+            "testId": "5002",
+            "score": 100,
+            "timeMs": 3,
+            "memoryKb": 26,
+            "errorCode": 0,
+            "output": "",
+            "expectedOutput": null,
+            "errorMessage": "",
+            "metadata": null,
+            "log": "",
+            "noFeedback": true,
+            "files": null,
+            "submissionSubtaskId": "7001",
+            "test": {
+              "id": "5002",
+              "submissionId": null,
+              "groupType": "Evaluation",
+              "userId": null,
+              "platformId": null,
+              "rank": 2,
+              "active": true,
+              "name": null,
+              "input": "15",
+              "output": "10",
+              "subtaskId": "4001",
+              "taskId": "1000",
+              "clientId": null
+            }
+          }
+        ]
+      }
+      """
+
   Scenario: Get evaluating submission by id using longPolling
     Given the database has the following table "tm_submissions":
       | ID   | idUser | idPlatform | idTask | sDate      | idSourceCode | bManualCorrection | bSuccess | nbTestsTotal | nbTestsPassed | iScore | bCompilError | bEvaluated | bConfirmed | sMode     | iChecksum | iVersion   |

--- a/src/platform_interface.ts
+++ b/src/platform_interface.ts
@@ -171,6 +171,10 @@ export async function sendSubmissionResultToPlatform(submission: Submission, sco
   const scoreToken = await generateScoreToken(submission, score);
 
   const platform = await getPlatformById(submission.idPlatform);
+  if (!platform.api_url) {
+    return;
+  }
+
   const platformUrl = `${platform.api_url}/items/save-grade`;
 
   const saveGradeRequest = {

--- a/src/submissions.ts
+++ b/src/submissions.ts
@@ -324,7 +324,7 @@ export function normalizeSourceCode(sourceCode: SourceCode): SourceCodeNormalize
   };
 }
 
-export async function getSubmission(submissionId: string): Promise<SubmissionOutput|null> {
+export async function getSubmission(submissionId: string, withTaskTests: boolean = false): Promise<SubmissionOutput|null> {
   const submission = await findSubmissionById(submissionId);
   if (null === submission) {
     return null;
@@ -341,7 +341,7 @@ export async function getSubmission(submissionId: string): Promise<SubmissionOut
 
   const submissionSubtasks = await Db.execute<SubmissionSubtask[]>('SELECT * FROM tm_submissions_subtasks WHERE idSubmission = ?', [submissionId]);
   const submissionTestResults = await Db.execute<SubmissionTest[]>('SELECT * FROM tm_submissions_tests WHERE idSubmission = ?', [submissionId]);
-  const submissionTests = await Db.execute<TaskTest[]>('SELECT * FROM tm_tasks_tests WHERE idSubmission = ? AND sGroupType = "User"', [submissionId]);
+  const submissionTests = await Db.execute<TaskTest[]>(`SELECT * FROM tm_tasks_tests WHERE (idSubmission = ? AND sGroupType = "User")${withTaskTests ? " OR (idTask = ?)" : ''}`, [submissionId, ...(withTaskTests ? [submission.idTask] : [])]);
 
   return {
     ...normalizeSubmission(submission),

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -4,6 +4,7 @@ import {extractPlatformTaskTokenData, PlatformTaskTokenData} from "./platform_in
 import {pipe} from "fp-ts/function";
 import * as D from "io-ts/Decoder";
 import {normalizeSourceCode, SourceCodeNormalized} from "./submissions";
+import appConfig from "./config";
 
 export interface TaskNormalized {
   id: string,
@@ -175,6 +176,8 @@ export async function getTask(taskId: string, taskParameters: TaskQueryParameter
         ]
       );
     }
+  } else if (appConfig.testMode.accessSolutions) {
+    accessSolution = true;
   }
 
   if (null === taskSourceCodes) {


### PR DESCRIPTION
Add an option to return submission result with test content included.

It's necessary when the user makes the first submission on the task since at this point, the tests have not been generated yet hence are not known by the client.