### PR TITLE
Allow idUser = 0 and allow submission without answerToken in this case

### DIFF
--- a/src/grader_interface.ts
+++ b/src/grader_interface.ts
@@ -166,10 +166,6 @@ WHERE tm_submissions.ID = :idSubmission
     throw new InvalidInputError('Cannot find source code associated with this submission');
   }
 
-  if (!submissionData.answerToken && !appConfig.testMode.enabled && 'UserTest' !== submission.sMode) {
-    throw new InvalidInputError('Missing answerToken, required for this type of submission');
-  }
-
   let tests: TaskTest[] = [];
   if ('UserTest' === submission.sMode) {
     tests = await Db.execute<TaskTest[]>('SELECT tm_tasks_tests.* FROM tm_tasks_tests WHERE idUser = :idUser and idPlatform = :idPlatform and idTask = :idTask and idSubmission = :idSubmission ORDER BY iRank ASC', {

--- a/src/platform_interface.ts
+++ b/src/platform_interface.ts
@@ -49,7 +49,7 @@ export async function extractPlatformTaskTokenData(token: string|null|undefined,
     }
   }
 
-  if (!payload.idUser || (!payload.idItem && !payload.itemUrl)) {
+  if (undefined === payload.idUser || null === payload.idUser || (!payload.idItem && !payload.itemUrl)) {
     throw new InvalidInputError('Missing idUser or idItem in token');
   }
 

--- a/src/tokenization.ts
+++ b/src/tokenization.ts
@@ -7,7 +7,7 @@ import {InvalidInputError} from './error_handler';
 import * as Db from './db';
 
 export interface PlatformGenericTokenPayload {
-  idUser: string|number|null,
+  idUser: string|null,
   itemUrl: string|null,
   nbHintsGiven: number,
   idItem?: string,

--- a/src/tokenization.ts
+++ b/src/tokenization.ts
@@ -7,7 +7,7 @@ import {InvalidInputError} from './error_handler';
 import * as Db from './db';
 
 export interface PlatformGenericTokenPayload {
-  idUser: string|null,
+  idUser: string|number|null,
   itemUrl: string|null,
   nbHintsGiven: number,
   idItem?: string,


### PR DESCRIPTION
Context: when FioiTaskImporter generates a signed task token to test the task, this token contains idUser = 0. This should be valid, like it was in TaskPlatform. And in this case, the user should be allowed to create a submission on the test task to check that it works correctly.